### PR TITLE
elastic search script updates

### DIFF
--- a/src/scripts/datadog-install.sh
+++ b/src/scripts/datadog-install.sh
@@ -73,7 +73,7 @@ log "Installing DataDog plugin onto this machine using API Key [$API_KEY]"
 
 wget -q https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh -O $DD_AGENT
 chmod +x $DD_AGENT
-DD_API_KEY=$API_KEY $DD_AGENT
+DD_API_KEY=$API_KEY DD_AGENT_MAJOR_VERSION=7 $DD_AGENT
 rm /etc/datadog-agent/conf.d/elastic.d/auto_conf.yaml
 
 echo "instances:

--- a/src/scripts/elasticsearch-install.sh
+++ b/src/scripts/elasticsearch-install.sh
@@ -1133,6 +1133,9 @@ configure_elasticsearch()
     log "[configure_elasticsearch] configure elasticsearch heap size - $ES_HEAP megabytes"
     sed -i -e "s/^\-Xmx.*/-Xmx${ES_HEAP}m/" /etc/elasticsearch/jvm.options
     sed -i -e "s/^\-Xms.*/-Xms${ES_HEAP}m/" /etc/elasticsearch/jvm.options
+
+    log "[configure_elasticsearch] configure elasticsearch log4j options"
+    sed  "/-Dlog4j2.disable.jmx=true/a -Dlog4j2.formatMsgNoLookups=true" /etc/elasticsearch/jvm.options
 }
 
 configure_os_properties()

--- a/src/scripts/elasticsearch-install.sh
+++ b/src/scripts/elasticsearch-install.sh
@@ -1135,7 +1135,7 @@ configure_elasticsearch()
     sed -i -e "s/^\-Xms.*/-Xms${ES_HEAP}m/" /etc/elasticsearch/jvm.options
 
     log "[configure_elasticsearch] configure elasticsearch log4j options"
-    sed  "/-Dlog4j2.disable.jmx=true/a -Dlog4j2.formatMsgNoLookups=true" /etc/elasticsearch/jvm.options
+    sed -i -e "/-Dlog4j2.disable.jmx=true/a -Dlog4j2.formatMsgNoLookups=true" /etc/elasticsearch/jvm.options
 }
 
 configure_os_properties()


### PR DESCRIPTION
- Datadog version 7.x will be installed instead of 6.x
- Adding the log4j mitigation config in the jvm.options file so new machines will have it by default