### PR TITLE
Add allowed ElasticSearch versions

### DIFF
--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -32,7 +32,10 @@
         "6.4.1",
         "6.4.2",
         "6.4.3",
-        "6.5.0"
+        "6.5.0",
+        "6.8.23",
+        "7.17.9",
+        "8.6.2"
       ],
       "metadata": {
         "description": "Elasticsearch version to install"


### PR DESCRIPTION
Add 6.8.23, 7.17.9 and 8.6.2 as allowed ElasticSearch versions.