### PR TITLE
Tightening the SSH inbound rules in kibana\jumpbox nsgs

### DIFF
--- a/src/machines/jumpbox-resources.json
+++ b/src/machines/jumpbox-resources.json
@@ -73,7 +73,16 @@
         }
       }
     },
-    "osProfile": "[variables(concat(parameters('credentials').authenticationType, '_osProfile'))]"
+    "osProfile": "[variables(concat(parameters('credentials').authenticationType, '_osProfile'))]",
+    "regionalSourcePrefixes": {  //Netskope publisher IP ranges by region, used to scope jumpbox NSG rules. 
+      "centralus": "104.43.135.6/31",
+      "westus2": "20.230.136.6/31",
+      "westeurope": "104.40.254.56/31",
+      "uksouth": "51.140.141.188/31",
+      "australiaeast": "20.92.240.8/31"
+    },
+    "normalizedLocation": "[replace(toLower(parameters('location')), ' ', '')]",
+    "jumpboxSourcePrefix": "[if(contains(variables('regionalSourcePrefixes'), variables('normalizedLocation')), variables('regionalSourcePrefixes')[variables('normalizedLocation')], 'Internet')]"
   },
   "resources": [
     {
@@ -87,13 +96,13 @@
       "properties": {
         "securityRules": [
           {
-            "name": "SSH",
+            "name": "SSH-Netskope",
             "properties": {
-              "description": "Allows SSH traffic",
+              "description": "[concat('SSH only allowed from Netskope publisher in ', variables('normalizedLocation'))]",
               "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('osSettings').managementPort]",
-              "sourceAddressPrefix": "*",
+              "sourceAddressPrefix": "[variables('jumpboxSourcePrefix')]",
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "priority": 100,

--- a/src/machines/kibana-resources.json
+++ b/src/machines/kibana-resources.json
@@ -100,13 +100,13 @@
       "properties": {
         "securityRules": [
           {
-            "name": "SSH",
+            "name": "SSH-Internal",
             "properties": {
-              "description": "Allows inbound SSH traffic from anyone",
+              "description": "Allows SSH traffic from private vnet connections only (jumpbox)",
               "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('osSettings').managementPort]",
-              "sourceAddressPrefix": "*",
+              "sourceAddressPrefix": "VirtualNetwork",
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "priority": 100,


### PR DESCRIPTION
Tightening the SSH inbound rules for Kibana and Jumpbox nodes
Allow SSH connection to Kibana nodes only from same vnet 
Allow SSH connection to Jumpbox nodes only from Netskope publisher